### PR TITLE
Enable checksum validation in HCS Live Migration

### DIFF
--- a/internal/hcs/system.go
+++ b/internal/hcs/system.go
@@ -986,10 +986,13 @@ func (computeSystem *System) HcsInitializeLiveMigrationOnSource(ctx context.Cont
 			options.MemoryTransport = hcsschema.MigrationMemoryTransportTCP
 		}
 		options.CancelIfBlackoutThresholdExceeds = opt.CancelIfBlackoutThresholdExceeds
-		options.PerfTracingEnabled = opt.PerfTracingEnabled
-		options.ChecksumVerification = opt.ChecksumVerification
+		//options.PerfTracingEnabled = opt.PerfTracingEnabled
+		//options.ChecksumVerification = opt.ChecksumVerification
 		options.PrepareMemoryTransferMode = opt.PrepareMemoryTransferMode
 	}
+	//knagendra Hardcoding these values to enable checksum verification in canary
+	options.PerfTracingEnabled = true
+	options.ChecksumVerification = true
 
 	optionsRaw, err := json.Marshal(options)
 	if err != nil {

--- a/internal/taskserver/migration.go
+++ b/internal/taskserver/migration.go
@@ -14,6 +14,8 @@ import (
 	"time"
 	"unsafe"
 
+	"golang.org/x/sys/windows/registry"
+
 	runhcsopts "github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options"
 	"github.com/Microsoft/hcsshim/internal/cmd"
 	"github.com/Microsoft/hcsshim/internal/core"
@@ -57,6 +59,9 @@ type migrationState struct {
 var _ lmproto.MigrationService = (*service)(nil)
 
 func (s *service) PrepareSandbox(ctx context.Context, req *lmproto.PrepareSandboxRequest) (*lmproto.PrepareSandboxResponse, error) {
+	if err := enableChecksumValidationRegKeys(); err != nil {
+        logrus.WithError(err).Warn("failed to set checksum validation registry keys")
+    }
 	sandboxState, resources, err := s.sandbox.Sandbox.(core.Migratable).LMPrepare(ctx, req.InitializeOptions)
 	if err != nil {
 		return nil, fmt.Errorf("prepare sandbox for migration: %w", err)
@@ -537,4 +542,24 @@ func (s *service) CreateDuplicateSocket(ctx context.Context, req *lmproto.Create
 	return &lmproto.CreateDuplicateSocketResponse{
 		SessionId: req.SessionId,
 	}, nil
+}
+
+func enableChecksumValidationRegKeys() error {
+    k, _, err := registry.CreateKey(
+        registry.LOCAL_MACHINE,
+        `SOFTWARE\Microsoft\Windows NT\CurrentVersion\Virtualization\Migration`,
+        registry.SET_VALUE,
+    )
+    if err != nil {
+        return fmt.Errorf("open migration registry key: %w", err)
+    }
+    defer k.Close()
+
+    if err := k.SetDWordValue("Test_UseSkippedForProtectionBitmapsInCrcCheck", 0); err != nil {
+        return fmt.Errorf("set Test_UseSkippedForProtectionBitmapsInCrcCheck: %w", err)
+    }
+    if err := k.SetDWordValue("Test_TransferMemoryAfterVdevPowerOff", 1); err != nil {
+        return fmt.Errorf("set Test_TransferMemoryAfterVdevPowerOff: %w", err)
+    }
+    return nil
 }

--- a/internal/vm2/vm.go
+++ b/internal/vm2/vm.go
@@ -172,6 +172,8 @@ func NewVM(ctx context.Context, id string, config *Config, opts ...Opt) (_ *VM, 
 				CompatibilityData: &hcsschema.CompatibilityInfo{
 					Data: oc.compatData,
 				},
+				ChecksumVerification: true,
+				PerfTracingEnabled:  true,
 			}
 		}
 


### PR DESCRIPTION
Enable checksum verification of guest memory pages during live migration by setting ChecksumVerification: true in the HCS options and adding the required registry keys (Test_UseSkippedForProtectionBitmapsInCrcCheck, Test_TransferMemoryAfterVdevPowerOff) in PrepareSandbox.