### PR TITLE
Add v2 computecore handle for live migration event callbacks

### DIFF
--- a/internal/computecore/computecore.go
+++ b/internal/computecore/computecore.go
@@ -1,6 +1,7 @@
 package computecore
 
 import (
+	"fmt"
 	"syscall"
 	"unsafe"
 
@@ -92,18 +93,63 @@ const (
 type HCS_EVENT_TYPE int
 
 const (
-	HcsEventTypeInvalid HCS_EVENT_TYPE = iota
-	HcsEventTypeSystemExited
-	HcsEventTypeSystemCrashInitiated
-	HcsEventTypeSystemCrashReport
-	HcsEventTypeSystemRdpEnhancedModeStateChanged
-	HcsEventTypeSystemSiloJobCreated
-	HcsEventTypeSystemGuestConnectionClosed
+	HcsEventTypeInvalid HCS_EVENT_TYPE = 0x00000000
 
-	HcsEventTypeProcessExited     HCS_EVENT_TYPE = 0x00010000
+	// Events for HCS_SYSTEM handles
+	HcsEventTypeSystemExited                      HCS_EVENT_TYPE = 0x00000001
+	HcsEventTypeSystemCrashInitiated              HCS_EVENT_TYPE = 0x00000002
+	HcsEventTypeSystemCrashReport                 HCS_EVENT_TYPE = 0x00000003
+	HcsEventTypeSystemRdpEnhancedModeStateChanged HCS_EVENT_TYPE = 0x00000004
+	HcsEventTypeSystemSiloJobCreated              HCS_EVENT_TYPE = 0x00000005
+	HcsEventTypeSystemGuestConnectionClosed       HCS_EVENT_TYPE = 0x00000006
+
+	// Events for HCS_PROCESS handles
+	HcsEventTypeProcessExited HCS_EVENT_TYPE = 0x00010000
+
+	// Common events
 	HcsEventTypeOperationCallback HCS_EVENT_TYPE = 0x01000000
 	HcsEventTypeServiceDisconnect HCS_EVENT_TYPE = 0x02000000
+
+	// Event groups (enabled by HCS_EVENT_OPTIONS)
+	HcsEventTypeGroupVmLifecycle   HCS_EVENT_TYPE = 0x80000002
+	HcsEventTypeGroupLiveMigration HCS_EVENT_TYPE = 0x80000003
+
+	// Events for HCS_OPERATION
+	HcsEventTypeGroupOperationInfo HCS_EVENT_TYPE = 0xC0000001
 )
+
+func (hn HCS_EVENT_TYPE) String() string {
+	switch hn {
+	case HcsEventTypeInvalid:
+		return "Invalid"
+	case HcsEventTypeSystemExited:
+		return "SystemExited"
+	case HcsEventTypeSystemCrashInitiated:
+		return "SystemCrashInitiated"
+	case HcsEventTypeSystemCrashReport:
+		return "SystemCrashReport"
+	case HcsEventTypeSystemRdpEnhancedModeStateChanged:
+		return "SystemRdpEnhancedModeStateChanged"
+	case HcsEventTypeSystemSiloJobCreated:
+		return "SystemSiloJobCreated"
+	case HcsEventTypeSystemGuestConnectionClosed:
+		return "SystemGuestConnectionClosed"
+	case HcsEventTypeProcessExited:
+		return "ProcessExited"
+	case HcsEventTypeOperationCallback:
+		return "OperationCallback"
+	case HcsEventTypeServiceDisconnect:
+		return "ServiceDisconnect"
+	case HcsEventTypeGroupVmLifecycle:
+		return "GroupVmLifecycle"
+	case HcsEventTypeGroupLiveMigration:
+		return "GroupLiveMigration"
+	case HcsEventTypeGroupOperationInfo:
+		return "GroupOperationInfo"
+	default:
+		return fmt.Sprintf("Unknown: 0x%08X", uint32(hn))
+	}
+}
 
 type Event struct {
 	Type      HCS_EVENT_TYPE
@@ -114,8 +160,9 @@ type Event struct {
 type HCS_EVENT_OPTIONS int
 
 const (
-	HcsEventOptionNone                     HCS_EVENT_OPTIONS = 0
-	HcsEventOptionEnableOperationCallbacks HCS_EVENT_OPTIONS = 1
+	HcsEventOptionNone                      HCS_EVENT_OPTIONS = 0
+	HcsEventOptionEnableOperationCallbacks  HCS_EVENT_OPTIONS = 1
+	HcsEventOptionEnableLiveMigrationEvents HCS_EVENT_OPTIONS = 4
 )
 
 type HCS_RESOURCE_TYPE int

--- a/internal/hcs/callbackV2.go
+++ b/internal/hcs/callbackV2.go
@@ -1,0 +1,87 @@
+//go:build windows
+
+package hcs
+
+import (
+	"sync"
+	"syscall"
+	"unsafe"
+
+	"github.com/Microsoft/hcsshim/internal/computecore"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/windows"
+)
+
+var (
+	nextCallbackV2    uintptr
+	callbackMapV2     = map[uintptr]*notificationWatcherContextV2{}
+	callbackMapLockV2 = sync.RWMutex{}
+
+	notificationWatcherCallbackV2 = syscall.NewCallback(notificationWatcherV2)
+)
+
+type notificationWatcherContextV2 struct {
+	channels notificationChannelsV2
+	systemID string
+}
+
+// notificationChannelV2 carries the event data string from LM notifications.
+type notificationChannelV2 chan string
+
+type notificationChannelsV2 map[computecore.HCS_EVENT_TYPE]notificationChannelV2
+
+func newLiveMigrationChannels() notificationChannelsV2 {
+	channels := make(notificationChannelsV2)
+	// Live migration group events (SetupDone, BlackoutStarted, OfflineDone,
+	// MigrationDone, TransferInProgress, etc.)
+	channels[computecore.HcsEventTypeGroupLiveMigration] = make(notificationChannelV2, 16)
+	return channels
+}
+
+func closeChannelsV2(channels notificationChannelsV2) {
+	for _, c := range channels {
+		close(c)
+	}
+}
+
+// notificationWatcherV2 is the v2 callback function invoked by computecore.dll.
+// Signature matches HCS_EVENT_CALLBACK: func(event *HCS_EVENT, context uintptr).
+func notificationWatcherV2(eventPtr uintptr, callbackNumber uintptr) uintptr {
+	callbackMapLockV2.RLock()
+	context := callbackMapV2[callbackNumber]
+	callbackMapLockV2.RUnlock()
+
+	if context == nil {
+		return 0
+	}
+
+	e := (*computecore.Event)(unsafe.Pointer(eventPtr))
+	if e == nil {
+		return 0
+	}
+
+	eventData := ""
+	if e.EventData != nil {
+		eventData = windows.UTF16PtrToString(e.EventData)
+	}
+
+	logrus.WithFields(logrus.Fields{
+		"event-type": e.Type.String(),
+		"system-id":  context.systemID,
+		"event-data": eventData,
+	}).Debug("HCS v2 notification")
+
+	if channel, ok := context.channels[e.Type]; ok {
+		// Non-blocking send — drop if channel is full to avoid blocking HCS callback thread.
+		select {
+		case channel <- eventData:
+		default:
+			logrus.WithFields(logrus.Fields{
+				"event-type": e.Type.String(),
+				"system-id":  context.systemID,
+			}).Warn("HCS v2 notification channel full, dropping event")
+		}
+	}
+
+	return 0
+}

--- a/internal/hcs/system.go
+++ b/internal/hcs/system.go
@@ -34,6 +34,13 @@ type System struct {
 	id             string
 	callbackNumber uintptr
 
+	// v2Handle is a separate computecore handle opened for the same system,
+	// used exclusively for receiving live migration event notifications via
+	// the v2 callback API (HcsSetComputeSystemCallback). This avoids
+	// conflicting with the legacy v1 callback registered on 'handle'.
+	v2Handle         computecore.HCS_SYSTEM
+	callbackNumberV2 uintptr
+
 	closedWaitOnce sync.Once
 	waitBlock      chan struct{}
 	waitError      error
@@ -866,6 +873,11 @@ func (computeSystem *System) CloseCtx(ctx context.Context) (err error) {
 		close(computeSystem.waitBlock)
 	})
 
+	// Clean up v2 handle if it was opened
+	if err = computeSystem.closeV2(ctx); err != nil {
+		return makeSystemError(computeSystem, operation, err, nil)
+	}
+
 	return nil
 }
 
@@ -925,6 +937,114 @@ func (computeSystem *System) unregisterCallback(ctx context.Context) error {
 	handle = 0 //nolint:ineffassign
 
 	return nil
+}
+
+// OpenV2Handle opens a second handle to the same compute system using the v2
+// computecore API and registers a v2 callback for live migration events.
+// This must be called after the system is created/opened with a v1 handle.
+func (computeSystem *System) OpenV2Handle(ctx context.Context) error {
+	operation := "hcs::System::OpenV2Handle"
+
+	var handle computecore.HCS_SYSTEM
+	err := computecore.HcsOpenComputeSystem(computeSystem.id, syscall.GENERIC_ALL, &handle)
+	if err != nil {
+		return makeSystemError(computeSystem, operation, err, nil)
+	}
+	computeSystem.v2Handle = handle
+
+	if err = computeSystem.registerCallbackV2(ctx); err != nil {
+		computecore.HcsCloseComputeSystem(computeSystem.v2Handle)
+		computeSystem.v2Handle = 0
+		return makeSystemError(computeSystem, operation, err, nil)
+	}
+	return nil
+}
+
+func (computeSystem *System) registerCallbackV2(ctx context.Context) error {
+	callbackContext := &notificationWatcherContextV2{
+		channels: newLiveMigrationChannels(),
+		systemID: computeSystem.id,
+	}
+
+	callbackMapLockV2.Lock()
+	callbackNumber := nextCallbackV2
+	nextCallbackV2++
+	callbackMapV2[callbackNumber] = callbackContext
+	callbackMapLockV2.Unlock()
+
+	err := computecore.HcsSetComputeSystemCallback(
+		computeSystem.v2Handle,
+		computecore.HcsEventOptionEnableLiveMigrationEvents,
+		callbackNumber,
+		notificationWatcherCallbackV2,
+	)
+	if err != nil {
+		callbackMapLockV2.Lock()
+		delete(callbackMapV2, callbackNumber)
+		callbackMapLockV2.Unlock()
+		return err
+	}
+
+	computeSystem.callbackNumberV2 = callbackNumber
+	return nil
+}
+
+func (computeSystem *System) unregisterCallbackV2(ctx context.Context) error {
+	callbackNumber := computeSystem.callbackNumberV2
+
+	callbackMapLockV2.RLock()
+	callbackContext := callbackMapV2[callbackNumber]
+	callbackMapLockV2.RUnlock()
+
+	if callbackContext == nil {
+		return nil
+	}
+
+	// Unregister by passing callback=0
+	err := computecore.HcsSetComputeSystemCallback(
+		computeSystem.v2Handle,
+		computecore.HcsEventOptionNone,
+		0,
+		0,
+	)
+	if err != nil {
+		return err
+	}
+
+	closeChannelsV2(callbackContext.channels)
+
+	callbackMapLockV2.Lock()
+	delete(callbackMapV2, callbackNumber)
+	callbackMapLockV2.Unlock()
+
+	return nil
+}
+
+// closeV2 cleans up the v2 handle and its callback.
+func (computeSystem *System) closeV2(ctx context.Context) error {
+	if computeSystem.v2Handle == 0 {
+		return nil
+	}
+
+	if err := computeSystem.unregisterCallbackV2(ctx); err != nil {
+		return err
+	}
+
+	computecore.HcsCloseComputeSystem(computeSystem.v2Handle)
+	computeSystem.v2Handle = 0
+	return nil
+}
+
+// LMNotificationChannel returns the channel that receives live migration
+// event data strings from the v2 callback.
+func (computeSystem *System) LMNotificationChannel() <-chan string {
+	callbackMapLockV2.RLock()
+	ctx := callbackMapV2[computeSystem.callbackNumberV2]
+	callbackMapLockV2.RUnlock()
+	if ctx == nil {
+		return nil
+	}
+	return ctx.channels[computecore.HcsEventTypeGroupLiveMigration]
 }
 
 // Modify the System by sending a request to HCS
@@ -998,7 +1118,7 @@ func (computeSystem *System) HcsInitializeLiveMigrationOnSource(ctx context.Cont
 	if err != nil {
 		return err
 	}
-	if err := computecore.HcsInitializeLiveMigrationOnSource(computecore.HCS_SYSTEM(computeSystem.handle), op, string(optionsRaw)); err != nil {
+	if err := computecore.HcsInitializeLiveMigrationOnSource(computeSystem.v2Handle, op, string(optionsRaw)); err != nil {
 		return err
 	}
 	if _, err := op.WaitResult(windows.INFINITE); err != nil {
@@ -1025,7 +1145,7 @@ func (computeSystem *System) HcsStartLiveMigrationOnSource(ctx context.Context, 
 	if err != nil {
 		return err
 	}
-	if err := computecore.HcsStartLiveMigrationOnSource(computecore.HCS_SYSTEM(computeSystem.handle), op, string(optionsRaw)); err != nil {
+	if err := computecore.HcsStartLiveMigrationOnSource(computeSystem.v2Handle, op, string(optionsRaw)); err != nil {
 		return err
 	}
 	if _, err := op.WaitResult(windows.INFINITE); err != nil {
@@ -1045,7 +1165,7 @@ func (computeSystem *System) HcsStartLiveMigrationTransfer(ctx context.Context) 
 	if err != nil {
 		return err
 	}
-	if err := computecore.HcsStartLiveMigrationTransfer(computecore.HCS_SYSTEM(computeSystem.handle), op, string(optionsRaw)); err != nil {
+	if err := computecore.HcsStartLiveMigrationTransfer(computeSystem.v2Handle, op, string(optionsRaw)); err != nil {
 		return err
 	}
 	if _, err := op.WaitResult(windows.INFINITE); err != nil {
@@ -1068,7 +1188,7 @@ func (computeSystem *System) HcsFinalizeLiveMigation(ctx context.Context, resume
 	if err != nil {
 		return err
 	}
-	if err := computecore.HcsFinalizeLiveMigration(computecore.HCS_SYSTEM(computeSystem.handle), op, string(optionsRaw)); err != nil {
+	if err := computecore.HcsFinalizeLiveMigration(computeSystem.v2Handle, op, string(optionsRaw)); err != nil {
 		return err
 	}
 	if _, err := op.WaitResult(windows.INFINITE); err != nil {

--- a/internal/vm2/vm.go
+++ b/internal/vm2/vm.go
@@ -173,7 +173,7 @@ func NewVM(ctx context.Context, id string, config *Config, opts ...Opt) (_ *VM, 
 					Data: oc.compatData,
 				},
 				ChecksumVerification: true,
-				PerfTracingEnabled:  true,
+				PerfTracingEnabled:   true,
 			}
 		}
 
@@ -192,6 +192,13 @@ func NewVM(ctx context.Context, id string, config *Config, opts ...Opt) (_ *VM, 
 			_ = system.Close()
 		}
 	}()
+
+	// Open a second v2 handle for live migration event notifications.
+	// This is separate from the v1 handle used for standard system operations.
+	if err = system.OpenV2Handle(ctx); err != nil {
+		return nil, err
+	}
+
 	props, err := system.Properties(ctx)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Add v2 computecore handle for live migration event callbacks

Open a separate v2 handle (computecore.dll) alongside the existing v1 handle
(vmcompute.dll) and register HcsSetComputeSystemCallback with
HcsEventOptionEnableLiveMigrationEvents to receive LM notifications without
replacing the legacy v1 callback used for standard system operations.

Changes:
- computecore.go: Add explicit HCS_EVENT_TYPE values, String(), and
  HcsEventOptionEnableLiveMigrationEvents flag
- callbackV2.go: New file - v2 callback handler with diagnostic logging
  to C:\Temp\hcs_lm_events.json
- system.go: Add v2Handle, OpenV2Handle, registerCallbackV2,
  unregisterCallbackV2, closeV2; route LM APIs through v2Handle
- vm.go: Call OpenV2Handle after system create/open