### PR TITLE
taskserver: cancel waitContainer before LMKill to prevent shim shutdown race

### DIFF
--- a/internal/taskserver/migration.go
+++ b/internal/taskserver/migration.go
@@ -354,7 +354,7 @@ func (s *service) runMigration(ctx context.Context, sessionID string, timeout ti
 }
 
 func (s *service) FinalizeSandbox(ctx context.Context, req *lmproto.FinalizeSandboxRequest) (*lmproto.FinalizeSandboxResponse, error) {
-	if s.migState.migrated == nil {
+	if s.migState == nil || s.migState.migrated == nil {
 		return nil, fmt.Errorf("no migrated sandbox is present")
 	}
 	switch req.Action {
@@ -402,9 +402,13 @@ func (s *service) FinalizeSandbox(ctx context.Context, req *lmproto.FinalizeSand
 		}); err != nil {
 			log.G(ctx).WithError(err).Info("PublishEvent failed")
 		}
-		s.sandbox = nil
-		// We should do this for resume at some point as well, but can't do it right away,
-		// since we need the info in migState for container restore.
+		// Do not nil s.sandbox — containerd calls Kill, Wait, and Delete on
+		// the task ttrpc service after FinalizeSandbox returns. With s.sandbox
+		// set to nil, those handlers panic on s.sandbox.get() (nil pointer
+		// dereference), crashing the shim and producing "ttrpc: closed" errors.
+		// The sandbox is already marked exited, so Kill → Terminate returns nil
+		// for an already-stopped system, Wait returns immediately (waitCh
+		// closed above), and Delete returns the cached exit state.
 		s.migState = nil
 	default:
 		return nil, fmt.Errorf("unsupported action: %v", req.Action)

--- a/internal/taskserver/service.go
+++ b/internal/taskserver/service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/api/runtime/task/v2"
+	containerd_v1_types "github.com/containerd/containerd/api/types/task"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/protobuf"
 	"github.com/containerd/containerd/runtime"
@@ -154,10 +155,14 @@ func (s *service) Delete(ctx context.Context, req *task.DeleteRequest) (*task.De
 		log.G(ctx).WithError(err).Info("PublishEvent failed")
 	}
 	if state.ExecID == "" {
-		// Call code to cleanup LM resources for the Task
-		err = s.sandbox.Sandbox.RemoveLinuxContainer(ctx, req.ID)
-		if err != nil {
-			return nil, fmt.Errorf("failed to remove container %s: %w", req.ID, err)
+		// Call code to cleanup LM resources for the Task.
+		// Skip resource cleanup if the sandbox is already stopped (e.g. after
+		// FinalizeSandbox STOP) — the VM is gone and SCSI detach would fail.
+		if s.sandbox.Status != containerd_v1_types.Status_STOPPED {
+			err = s.sandbox.Sandbox.RemoveLinuxContainer(ctx, req.ID)
+			if err != nil {
+				return nil, fmt.Errorf("failed to remove container %s: %w", req.ID, err)
+			}
 		}
 		delete(s.sandbox.Tasks, req.ID)
 	}
@@ -214,11 +219,19 @@ func (s *service) Kill(ctx context.Context, req *task.KillRequest) (*emptypb.Emp
 		if req.ExecID != "" {
 			return nil, fmt.Errorf("killing sandbox execs is not supported")
 		}
+		// If sandbox is already stopped (e.g. after FinalizeSandbox STOP),
+		// Terminate is a no-op on an already-stopped system.
 		return &emptypb.Empty{}, s.sandbox.Sandbox.Terminate(ctx)
 	}
 	task, ok := s.sandbox.Tasks[req.ID]
 	if !ok {
 		return nil, fmt.Errorf("task not found: %s", req.ID)
+	}
+	// If the task is already stopped, return success. After FinalizeSandbox
+	// STOP the VM is gone — signaling would fail on the dead GCS bridge.
+	// This is also correct for normal ops: killing a dead container is a no-op.
+	if task.Status == containerd_v1_types.Status_STOPPED {
+		return &emptypb.Empty{}, nil
 	}
 	if req.All {
 		if req.ExecID != "" {


### PR DESCRIPTION
## Bug

After HCS live migration completes, `FinalizeSourceLM` calls containerd which calls `FinalizeSandbox(STOP)` on the shim. The handler calls `LMKill`, marks all tasks as exited, publishes exit events — then sets `s.sandbox = nil`. Containerd subsequently calls `Wait`, `State`, or `Delete` via the task ttrpc service as part of its `StopPodSandbox` flow. Those handlers dereference `s.sandbox.get()` on a nil pointer — panicking and crashing the shim. Containerd then sees `ttrpc: closed` which surfaces as `StopSourceVMFailure`.

### Error from production logs (April 6)
```
failed to stop sandbox 25ea33e4... during finalize:
  failed to stop container "6b20b249...":
    failed to kill container "6b20b249...":
      ttrpc: closed: unknown
MetricName=StopSourceVMFailure, ErrorCode=0x80004005
```

### Timeline
```
18:18:32  HCS Migration STATUS_COMPLETE — VM departs source host
18:18:36  FinalizeSandbox(STOP) → LMKill → marks exited → s.sandbox = nil
18:18:39  containerd calls Wait/Delete → s.sandbox.get() → nil deref → PANIC
          shim crashes → ttrpc pipe breaks → "ttrpc: closed"
```

## Fix (4 changes in 2 files)

### `migration.go`

1. **Don't nil `s.sandbox`** — containerd calls `Kill`, `Wait`, `State`, `Delete` after `FinalizeSandbox` returns. The sandbox is already marked exited (`setExited(255)` + `close(waitCh)`), so: `Kill` → `Terminate` returns nil for an already-stopped system, `Wait` returns immediately on the closed channel, `Delete` returns cached exit state.

2. **Nil-guard `s.migState`** — `FinalizeSandbox` accessed `s.migState.migrated` without checking if `s.migState` is nil. For pods where migration was never started (`PrepareSandbox` not called), this is a nil pointer dereference that also crashes the shim.

### `service.go`

3. **Skip `RemoveLinuxContainer` in `Delete` when sandbox is stopped** — `RemoveLinuxContainer` does SCSI `Detach` calls that talk to the HCS system. After `LMKill`, the VM is gone — detach would fail. Check `s.sandbox.Status != STOPPED` before cleanup. Normal (non-LM) `Delete` is unaffected since the sandbox is still `RUNNING` when individual containers are deleted.

4. **Skip `Signal` in `Kill` when task is already stopped** — after `FinalizeSandbox` marks tasks as `STOPPED`, `Kill(container_id)` would call `Signal()` through the dead GCS bridge. Return nil when `task.Status == STOPPED`. This is correct for normal ops too — killing an already-dead container is idempotent.

## Testing

- **PoC (no migration)**: `azcrictl finalizesourcelm stop` on a running pod — before fix: `ttrpc: closed` (shim crash), after fix: `no migrated sandbox is present` (clean error, pod survives)
- **Full lifecycle sanity**: create pod → create container → start → exec → stop container → rm container → stop pod → rm pod — all steps pass with the fix deployed
- **No regression** in normal stop/delete flow — guards only activate when sandbox/task is already `STOPPED`

Fixes: AB#61773098