### PR TITLE
Revert checksum validation + stamp shim commit id

### DIFF
--- a/internal/hcs/system.go
+++ b/internal/hcs/system.go
@@ -986,13 +986,10 @@ func (computeSystem *System) HcsInitializeLiveMigrationOnSource(ctx context.Cont
 			options.MemoryTransport = hcsschema.MigrationMemoryTransportTCP
 		}
 		options.CancelIfBlackoutThresholdExceeds = opt.CancelIfBlackoutThresholdExceeds
-		//options.PerfTracingEnabled = opt.PerfTracingEnabled
-		//options.ChecksumVerification = opt.ChecksumVerification
+		options.PerfTracingEnabled = opt.PerfTracingEnabled
+		options.ChecksumVerification = opt.ChecksumVerification
 		options.PrepareMemoryTransferMode = opt.PrepareMemoryTransferMode
 	}
-	//knagendra Hardcoding these values to enable checksum verification in canary
-	options.PerfTracingEnabled = true
-	options.ChecksumVerification = true
 
 	optionsRaw, err := json.Marshal(options)
 	if err != nil {

--- a/internal/hcs/system.go
+++ b/internal/hcs/system.go
@@ -987,7 +987,11 @@ func (computeSystem *System) HcsInitializeLiveMigrationOnSource(ctx context.Cont
 		}
 		options.CancelIfBlackoutThresholdExceeds = opt.CancelIfBlackoutThresholdExceeds
 		options.PerfTracingEnabled = opt.PerfTracingEnabled
-		options.ChecksumVerification = opt.ChecksumVerification
+		// Checksum verification is intentionally never propagated to HCS: we do not
+		// want any instance of memory-page checksum validation active during live
+		// migration. Leaving options.ChecksumVerification at its zero value combined
+		// with the omitempty JSON tag omits it from the HCS payload entirely.
+		// options.ChecksumVerification = opt.ChecksumVerification
 		options.PrepareMemoryTransferMode = opt.PrepareMemoryTransferMode
 	}
 

--- a/internal/taskserver/migration.go
+++ b/internal/taskserver/migration.go
@@ -14,8 +14,6 @@ import (
 	"time"
 	"unsafe"
 
-	"golang.org/x/sys/windows/registry"
-
 	runhcsopts "github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options"
 	"github.com/Microsoft/hcsshim/internal/cmd"
 	"github.com/Microsoft/hcsshim/internal/core"
@@ -59,9 +57,6 @@ type migrationState struct {
 var _ lmproto.MigrationService = (*service)(nil)
 
 func (s *service) PrepareSandbox(ctx context.Context, req *lmproto.PrepareSandboxRequest) (*lmproto.PrepareSandboxResponse, error) {
-	if err := enableChecksumValidationRegKeys(); err != nil {
-        logrus.WithError(err).Warn("failed to set checksum validation registry keys")
-    }
 	sandboxState, resources, err := s.sandbox.Sandbox.(core.Migratable).LMPrepare(ctx, req.InitializeOptions)
 	if err != nil {
 		return nil, fmt.Errorf("prepare sandbox for migration: %w", err)
@@ -546,24 +541,4 @@ func (s *service) CreateDuplicateSocket(ctx context.Context, req *lmproto.Create
 	return &lmproto.CreateDuplicateSocketResponse{
 		SessionId: req.SessionId,
 	}, nil
-}
-
-func enableChecksumValidationRegKeys() error {
-    k, _, err := registry.CreateKey(
-        registry.LOCAL_MACHINE,
-        `SOFTWARE\Microsoft\Windows NT\CurrentVersion\Virtualization\Migration`,
-        registry.SET_VALUE,
-    )
-    if err != nil {
-        return fmt.Errorf("open migration registry key: %w", err)
-    }
-    defer k.Close()
-
-    if err := k.SetDWordValue("Test_UseSkippedForProtectionBitmapsInCrcCheck", 0); err != nil {
-        return fmt.Errorf("set Test_UseSkippedForProtectionBitmapsInCrcCheck: %w", err)
-    }
-    if err := k.SetDWordValue("Test_TransferMemoryAfterVdevPowerOff", 1); err != nil {
-        return fmt.Errorf("set Test_TransferMemoryAfterVdevPowerOff: %w", err)
-    }
-    return nil
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -2,6 +2,7 @@ package version
 
 import (
 	"embed"
+	"runtime/debug"
 	"strings"
 )
 
@@ -39,3 +40,36 @@ func readDataFile(f string) string {
 	b, _ := data.ReadFile("data/" + f)
 	return strings.TrimSpace(string(b))
 }
+
+// When the build did not populate the embedded data files (e.g. a plain
+// `go build` that did not run scripts/Set-VersionInfo.ps1 and passed no
+// `-ldflags -X` overrides), fall back to the VCS revision that the Go
+// toolchain embeds automatically (`go build -buildvcs`, default since Go 1.18).
+// This ensures binaries report the git commit they were built from.
+func init() {
+	if Commit != "" {
+		return
+	}
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	var revision string
+	var modified bool
+	for _, s := range bi.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			revision = s.Value
+		case "vcs.modified":
+			modified = s.Value == "true"
+		}
+	}
+	if revision == "" {
+		return
+	}
+	if modified {
+		revision += "-dirty"
+	}
+	Commit = revision
+}
+

--- a/internal/vm2/vm.go
+++ b/internal/vm2/vm.go
@@ -172,8 +172,6 @@ func NewVM(ctx context.Context, id string, config *Config, opts ...Opt) (_ *VM, 
 				CompatibilityData: &hcsschema.CompatibilityInfo{
 					Data: oc.compatData,
 				},
-				ChecksumVerification: true,
-				PerfTracingEnabled:  true,
 			}
 		}
 


### PR DESCRIPTION
Two commits:

1. Revert "Enable checksum validation in HCS Live Migration" (c4ac8439) - that was a canary diagnostic that hardcoded ChecksumVerification=true and set the migration CRC reg keys. Restores the original option-driven behaviour. For the ACI package we want checksum validation off.

2. version: fall back to the VCS revision that `go build` embeds, so the runhcs-v1 shim's `-v` shows the commit it was built from instead of an empty Revision.

Builds clean; shim `-v` now prints `commit: <sha>`.

For ACI packaging work item #38387077.